### PR TITLE
refactor: replace hardcoded paths with %USERNAME% in registry entries

### DIFF
--- a/add_cursor_ide_to_context_menu.reg
+++ b/add_cursor_ide_to_context_menu.reg
@@ -3,22 +3,22 @@ Windows Registry Editor Version 5.00
 ; Open Folder as Cursor Project when right-clicking ON a folder
 [HKEY_CLASSES_ROOT\Directory\shell\cursor]
 @="Open Folder as Cursor Project"
-"Icon"="C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
+"Icon"="C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
 [HKEY_CLASSES_ROOT\Directory\shell\cursor\command]
-@="\"C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%1\""
+@="\"C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%1\""
 
 ; Open Folder as Cursor Project when right-clicking INSIDE a folder
 [HKEY_CLASSES_ROOT\Directory\Background\shell\cursor]
 @="Open Folder as Cursor Project"
-"Icon"="C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
+"Icon"="C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
 [HKEY_CLASSES_ROOT\Directory\Background\shell\cursor\command]
-@="\"C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%V\""
+@="\"C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%V\""
 
 ; Optional: Open files with Cursor (Edit with Cursor)
 ; Uncomment the following block to add the "Edit with Cursor" option for files
 
 ; [HKEY_CLASSES_ROOT\*\shell\Open with Cursor]
 ; @="Edit with Cursor"
-; "Icon"="C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
+; "Icon"="C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe,0"
 ; [HKEY_CLASSES_ROOT\*\shell\Open with Cursor\command]
-; @="\"C:\\Users\\your_name\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%1\""
+; @="\"C:\\Users\\%USERNAME%\\AppData\\Local\\Programs\\cursor\\Cursor.exe\" \"%1\""


### PR DESCRIPTION
Updated the Windows Registry entries to use %USERNAME% instead of a hardcoded user path (e.g., `your_name`).

This ensures compatibility across different user accounts without requiring manual path modifications.